### PR TITLE
Enhancement/20

### DIFF
--- a/src/application/handler/command.rs
+++ b/src/application/handler/command.rs
@@ -5,9 +5,27 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use log::{debug, trace};
 use crate::application::handler::command::alarm::AlarmCommand;
-use crate::application::handler::command::Command::{Alarm, EventList, HealthCheck, HealthCheckAll, Logs, Nothing};
+use crate::application::handler::command::Command::{Alarm, EventList, HealthCheck, HealthCheckAll, Help, Logs, Nothing};
 use crate::application::handler::GeneralHandler;
 use crate::domain::client::Message;
+
+pub struct CommandMeta {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub usage: &'static str,
+    pub examples: &'static [&'static str],
+}
+
+impl CommandMeta {
+    pub const fn new(
+        name: &'static str,
+        description: &'static str,
+        usage: &'static str,
+        examples: &'static [&'static str],
+    ) -> Self {
+        Self { name, description, usage, examples }
+    }
+}
 
 #[async_trait]
 pub trait Run: Send + Sync {
@@ -22,6 +40,79 @@ pub enum Command {
     Nothing,
     Alarm(AlarmCommand),
     EventList,
+    Help(Option<String>),
+}
+
+impl Command {
+    const HELP: CommandMeta = CommandMeta::new(
+        "/help",
+        "커맨드 사용법을 표시합니다",
+        "/help [command]",
+        &["/help", "/help logs"],
+    );
+    const LOGS: CommandMeta = CommandMeta::new(
+        "/logs",
+        "서버의 최근 로그를 가져옵니다",
+        "/logs <server_name> <lines>",
+        &["/logs main 100", "/logs api 50"],
+    );
+    const HEALTH: CommandMeta = CommandMeta::new(
+        "/health",
+        "서버 헬스체크 결과를 확인합니다",
+        "/health [server_name]",
+        &["/health", "/health main"],
+    );
+    const ALARM: CommandMeta = CommandMeta::new(
+        "/alarm",
+        "이벤트 알람을 구독 또는 해제합니다",
+        "/alarm <add|remove|list> [event_name]",
+        &["/alarm list", "/alarm add cpu-high", "/alarm remove cpu-high"],
+    );
+    const EVENT: CommandMeta = CommandMeta::new(
+        "/event",
+        "설정된 이벤트 목록을 표시합니다",
+        "/event [list]",
+        &["/event", "/event list"],
+    );
+
+    pub fn meta(&self) -> Option<&'static CommandMeta> {
+        match self {
+            Help(_)                            => Some(&Self::HELP),
+            Logs(_, _)                         => Some(&Self::LOGS),
+            HealthCheck(_) | HealthCheckAll    => Some(&Self::HEALTH),
+            Alarm(_)                           => Some(&Self::ALARM),
+            EventList                          => Some(&Self::EVENT),
+            Nothing                            => None,
+        }
+    }
+
+    pub fn all_docs() -> &'static [&'static CommandMeta] {
+        &[&Self::HELP, &Self::LOGS, &Self::HEALTH, &Self::ALARM, &Self::EVENT]
+    }
+
+    pub fn render_help_all() -> String {
+        let list = Self::all_docs()
+            .iter()
+            .map(|m| format!("{} — {}", m.name, m.description))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("사용 가능한 커맨드:\n\n{list}\n\n자세한 사용법: /help <command>\n예시: /help logs")
+    }
+
+    pub fn render_help_one(name: &str) -> Option<String> {
+        let meta = Self::all_docs()
+            .iter()
+            .find(|m| m.name.trim_start_matches('/') == name)?;
+        let examples = meta.examples
+            .iter()
+            .map(|e| format!("  {e}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Some(format!(
+            "{} — {}\n\n사용법:\n  {}\n\n예시:\n{examples}",
+            meta.name, meta.description, meta.usage
+        ))
+    }
 }
 
 #[async_trait]
@@ -53,8 +144,13 @@ impl Run for Command {
                 let events = handler.event_config_use_case.list_event().await?;
                 let event_names = events.iter().map(|e| e.name.clone()).collect::<Vec<String>>().join("\n");
                 Ok(format!("Available events:\n{}", event_names))
-            }
-            Command::Nothing => Ok(String::from(crate::application::handler::general::INVALID_COMMAND_MESSAGE))
+            },
+            Command::Help(name) => match name {
+                None => Ok(Command::render_help_all()),
+                Some(name) => Command::render_help_one(name)
+                    .ok_or_else(|| anyhow!("알 수 없는 커맨드: /{name}\n\n{}", Command::render_help_all()).into()),
+            },
+            Command::Nothing => Ok(Command::render_help_all()),
         }
     }
 }
@@ -63,6 +159,8 @@ impl Command {
     pub fn parse(text: &str) -> Self {
         trace!("Command::parse(text: {})", &text);
         let command = match text.split_whitespace().collect::<Vec<_>>()[..] {
+            ["/help"] => Help(None),
+            ["/help", name] => Help(Some(name.trim_start_matches('/').to_string())),
             ["/health", name] => HealthCheck(name.to_string()),
             ["/health"] => HealthCheckAll,
             ["/logs", name, n] => {

--- a/src/application/handler/general.rs
+++ b/src/application/handler/general.rs
@@ -8,16 +8,6 @@ use crate::application::handler::MessageHandler;
 use crate::application::server::ServerManager;
 use crate::domain::client::Message;
 
-pub const INVALID_COMMAND_MESSAGE: &str = r#"Invalid or unknown command.
-
-Available commands:
-- /logs <server_name> <lines>
-  Fetches the last <lines> of logs from the specified server.
-  Example: /logs main 100
-
-- /health (server_name)
-  (server_name): optional. If provided, returns the health status of the specified server."#;
-
 use std::sync::Arc;
 
 #[derive(new)]


### PR DESCRIPTION
close #20

## Feature

- `/help` 커맨드 추가
  - `all_docs()` 기반으로 전체 커맨드 목록과 한 줄 설명을 자동 생성
- `/help <command>` 커맨드 추가
  - 특정 커맨드의 사용법과 예시를 상세 표시
  - `/help logs`, `/help /logs` 모두 동일하게 처리 (prefix `/` trim)
- `Command` enum에 선언적 문서화 통합
  - `CommandMeta` 구조체를 `command.rs`에 정의
  - `Command::LOGS`, `Command::HEALTH` 등 associated constants로 각 커맨드가 자신의 문서를 소유
  - `meta(&self)` 메서드로 variant와 메타데이터를 직접 연결
  - `all_docs()`, `render_help_all()`, `render_help_one()` 메서드 추가
- 기존 하드코딩된 `INVALID_COMMAND_MESSAGE` 제거
  - 잘못된 커맨드 입력 시 `all_docs()` 기반으로 자동 생성된 목록 반환